### PR TITLE
Fix member page not loading when navigating directly to /members/:id

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,7 +116,7 @@ function App({ fetchCurrentUser, firebaseUser }: Props) {
         <Route path={PROFILE} element={<Wrapper><MyProfilePage /></Wrapper>} />
         <Route path={ACCOUNT} element={<Wrapper><AccountPage /></Wrapper>} />
         <Route path={ABOUT_US} element={<Wrapper><AboutUsPage /></Wrapper>} />
-        <Route path={MEMBERS} element={<Wrapper><MembersPage /></Wrapper>} />
+        <Route path={`${MEMBERS}/*`} element={<Wrapper><MembersPage /></Wrapper>} />
         <Route path={USERS} element={<Wrapper><UsersPage /></Wrapper>} />
         <Route path={CONTACTS} element={<Wrapper><ContactsPage /></Wrapper>} />
         <Route path={FAQ} element={<Wrapper><FaqPage /></Wrapper>} />


### PR DESCRIPTION
Add wildcard to members route so React Router v6 matches both /members and /members/:id URLs.