### PR TITLE
Fix stepper landing on Profile instead of Membership after Stripe che…

### DIFF
--- a/src/pages/sign-up-page/SignUpPage.tsx
+++ b/src/pages/sign-up-page/SignUpPage.tsx
@@ -36,9 +36,15 @@ function SignUpPage({ isCurrentUserLoaded, firebaseUser }: Props) {
     return <></>
   }
 
+  // When returning from Stripe checkout, skip directly to the Membership step
+  const params = new URLSearchParams(window.location.search)
+  const initialStep = params.get('session_id')
+    ? Math.max(steps.indexOf(STEP_MEMBERSHIP), 0)
+    : 0
+
   return (
     <div style={{ maxWidth: 350 }} className="mx-auto mt-4">
-      <SignUpStepper steps={steps} />
+      <SignUpStepper steps={steps} initialStep={initialStep} />
     </div>
   )
 }

--- a/src/pages/sign-up-page/SignUpStepPayment.tsx
+++ b/src/pages/sign-up-page/SignUpStepPayment.tsx
@@ -220,40 +220,34 @@ function SignUpStepPayment({
     }
 
     // need to pay
-    if (checkoutMounted) {
-      return (
-        <>
-          <div ref={checkoutContainerRef} className="mt-3" />
-          {errorMessage && (
-            <div className="text-danger text-center mt-2">{errorMessage}</div>
-          )}
-        </>
-      )
-    }
-
     return (
       <>
-        <h6 className="mt-3">Membership fees</h6>
-        &bull; Adult (18 and over): $20
-        <br />
-        &bull; Kids: $10.
-        <br />
-        <h4 className="my-4">
-          Total amount: ${totalAmount > 0 ? totalAmount : ''}
-        </h4>
-        {membershipExpiresAt && (
-          <div className="text-success mb-3 text-center">
-            {dayjs(membershipExpiresAt).isAfter(dayjs())
-              ? `Your current membership expires on ${dayjs(membershipExpiresAt).format(
-                'MMMM Do YYYY'
-              )}`
-              : `Your membership expired on ${dayjs(membershipExpiresAt).format(
-                'MMMM Do YYYY'
-              )}`}
-          </div>
+        {!checkoutMounted && (
+          <>
+            <h6 className="mt-3">Membership fees</h6>
+            &bull; Adult (18 and over): $20
+            <br />
+            &bull; Kids: $10.
+            <br />
+            <h4 className="my-4">
+              Total amount: ${totalAmount > 0 ? totalAmount : ''}
+            </h4>
+            {membershipExpiresAt && (
+              <div className="text-success mb-3 text-center">
+                {dayjs(membershipExpiresAt).isAfter(dayjs())
+                  ? `Your current membership expires on ${dayjs(membershipExpiresAt).format(
+                    'MMMM Do YYYY'
+                  )}`
+                  : `Your membership expired on ${dayjs(membershipExpiresAt).format(
+                    'MMMM Do YYYY'
+                  )}`}
+              </div>
+            )}
+          </>
         )}
+        <div ref={checkoutContainerRef} className="mt-3" />
         {errorMessage && (
-          <div className="text-danger text-center">{errorMessage}</div>
+          <div className="text-danger text-center mt-2">{errorMessage}</div>
         )}
       </>
     )

--- a/src/pages/sign-up-page/SignUpStepper.tsx
+++ b/src/pages/sign-up-page/SignUpStepper.tsx
@@ -15,10 +15,11 @@ export const STEP_MEMBERSHIP = 'STEP_MEMBERSHIP'
 
 interface Props {
   steps: string[]
+  initialStep?: number
 }
 
-function SignUpStepper({ steps }: Props) {
-  const [activeStep, setActiveStep] = useState(0)
+function SignUpStepper({ steps, initialStep = 0 }: Props) {
+  const [activeStep, setActiveStep] = useState(initialStep)
 
   const handleNext = () => {
     setActiveStep(activeStep + 1)


### PR DESCRIPTION
…ckout

Two bugs prevented the confirmation from showing after payment:

1. After Stripe redirects back to /join?session_id=..., the stepper always started at step 0 (Profile). Fix: SignUpPage now detects the session_id URL param and passes initialStep to SignUpStepper so it skips directly to the Membership step.

2. The checkout container div was only rendered after checkoutMounted was true, but the mount call happened before that state change, so Stripe had no DOM node to mount into. Fix: always render the container div and toggle fee info visibility instead.