### PR TITLE
Fix iCal events showing midnight by including hour and minute

### DIFF
--- a/functions/src/Event.d.ts
+++ b/functions/src/Event.d.ts
@@ -2,6 +2,8 @@ interface Event {
   year: number
   month: number
   day: number
+  hour: number
+  minute: number
   subject: string
   where: string
   what: string

--- a/functions/src/generateICal.ts
+++ b/functions/src/generateICal.ts
@@ -54,7 +54,7 @@ const GenerateICal = () =>
       events
         .map(event => {
           event.month--
-          event.moment = dayjs.tz(new Date(event.year, event.month, event.day), 'America/Los_Angeles')
+          event.moment = dayjs.tz(new Date(event.year, event.month, event.day, event.hour || 0, event.minute || 0), 'America/Los_Angeles')
           return event
         })
         .filter(event => {


### PR DESCRIPTION
The iCal generator was constructing dates with only year/month/day, ignoring the hour and minute fields from the CSV. This caused all calendar events to show as midnight (12:00 AM).