### PR TITLE
Fix iCal generating 19k phantom events from empty spreadsheet rows

### DIFF
--- a/functions/src/generateICal.ts
+++ b/functions/src/generateICal.ts
@@ -58,7 +58,7 @@ const GenerateICal = () =>
           return event
         })
         .filter(event => {
-          return event.moment.isValid()
+          return event.year && event.month && event.day && event.moment.isValid()
         })
         .sort((a: EventEX, b: EventEX) => {
           return a.moment.valueOf() - b.moment.valueOf()


### PR DESCRIPTION
Empty rows in the Google Sheet were passing through the isValid() filter because new Date(0, -1, 0) produces a valid date (Nov 30, 1899). Adding checks for truthy year/month/day fields drops the event count from 19,350 to ~213 and resolves the phone SSL timeout error caused by the huge file.