### PR TITLE
Filter out past events from the upcoming events list

### DIFF
--- a/src/pages/home-page/schedule/EventSchedule.tsx
+++ b/src/pages/home-page/schedule/EventSchedule.tsx
@@ -113,8 +113,12 @@ function EventSchedule() {
     if (!events.length) {
       return
     }
+    const startOfToday = dayjs().startOf('day')
     const res = events.filter((event: { moment: Dayjs }) => {
-      return event.moment.isBefore(dayjs().add(daysAhead, 'day'))
+      return (
+        !event.moment.isBefore(startOfToday) &&
+        event.moment.isBefore(dayjs().add(daysAhead, 'day'))
+      )
     })
     setFilteredEvents(res)
   }, [events, daysAhead])


### PR DESCRIPTION
The frontend only checked the upper bound (daysAhead) when filtering events, so past events stored in Firestore would continue to render until the backend update job pruned them. Add a lower-bound check against the start of today so past events are hidden immediately.