### PR TITLE
Fix updateEvents Cloud Function not saving events to Firestore

### DIFF
--- a/functions/src/updateEvents.ts
+++ b/functions/src/updateEvents.ts
@@ -1,9 +1,11 @@
 import * as Admin from 'firebase-admin'
 import dayjs, { Dayjs } from 'dayjs'
 import isBetween from 'dayjs/plugin/isBetween'
+import objectSupport from 'dayjs/plugin/objectSupport'
 import got from 'got'
 
 dayjs.extend(isBetween)
+dayjs.extend(objectSupport)
 
 const csv = require('csvtojson')
 const request = require('request')


### PR DESCRIPTION
The moment.js → dayjs migration (c6e88ed) forgot to register the objectSupport plugin in updateEvents.ts. Without it, dayjs(event) returns an invalid date for plain objects, causing every event to fail the isValid() filter, resulting in an empty array and an early return before writing to Firestore.

The frontend EventSchedule.tsx already had objectSupport registered, which is why event display logic worked once data was in Firestore.