### PR TITLE
Upgrade Stripe SDK v8 → v22

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -19,7 +19,7 @@
         "normalize-email": "^1.1.1",
         "parse-full-name": "^1.2.6",
         "request": "^2.88.2",
-        "stripe": "^8.210.0",
+        "stripe": "^22.3.2",
         "underscore": "^1.13.8"
       },
       "devDependencies": {
@@ -5423,15 +5423,20 @@
       }
     },
     "node_modules/stripe": {
-      "version": "8.210.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.210.0.tgz",
-      "integrity": "sha512-NDQNEInrr1avwSEDB7Phe7PYNejtU9EkhOBlPa90Aomc3WvSXgOuX8MpswQ1mTw+W/lGpePwVqMsUvrvhUjZfA==",
-      "dependencies": {
-        "@types/node": ">=8.1.0",
-        "qs": "^6.6.0"
-      },
+      "version": "22.3.2",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.3.2.tgz",
+      "integrity": "sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==",
+      "license": "MIT",
       "engines": {
-        "node": "^8.1 || >=10.*"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/strnum": {
@@ -9702,13 +9707,10 @@
       }
     },
     "stripe": {
-      "version": "8.210.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.210.0.tgz",
-      "integrity": "sha512-NDQNEInrr1avwSEDB7Phe7PYNejtU9EkhOBlPa90Aomc3WvSXgOuX8MpswQ1mTw+W/lGpePwVqMsUvrvhUjZfA==",
-      "requires": {
-        "@types/node": ">=8.1.0",
-        "qs": "^6.6.0"
-      }
+      "version": "22.3.2",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.3.2.tgz",
+      "integrity": "sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==",
+      "requires": {}
     },
     "strnum": {
       "version": "2.1.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -37,7 +37,7 @@
     "normalize-email": "^1.1.1",
     "parse-full-name": "^1.2.6",
     "request": "^2.88.2",
-    "stripe": "^8.210.0",
+    "stripe": "^22.3.2",
     "underscore": "^1.13.8"
   },
   "devDependencies": {

--- a/functions/src/stripe.ts
+++ b/functions/src/stripe.ts
@@ -36,10 +36,10 @@ interface StripeConfig {
 
 const Stripe = (admin: Admin.app.App, config: StripeConfig) => {
   const stripeLive = new StripeAPI(config.secretKeys.live, {
-    apiVersion: '2020-08-27'
+    apiVersion: '2026-06-24.dahlia'
   })
   const stripeTest = new StripeAPI(config.secretKeys.test, {
-    apiVersion: '2020-08-27'
+    apiVersion: '2026-06-24.dahlia'
   })
 
   const firestore = admin.firestore()
@@ -87,10 +87,8 @@ const Stripe = (admin: Admin.app.App, config: StripeConfig) => {
     const stripe = getStripeInstance(origin)
 
     try {
-      // Using 'as any' because stripe SDK v8 types don't include embedded checkout fields,
-      // but the Stripe API supports them at runtime
       const session = await stripe.checkout.sessions.create({
-        ui_mode: 'embedded',
+        ui_mode: 'embedded_page',
         mode: 'payment',
         line_items: [{
           price_data: {
@@ -106,9 +104,9 @@ const Stripe = (admin: Admin.app.App, config: StripeConfig) => {
         customer_email: customerEmail,
         metadata: { uid },
         return_url: returnUrl,
-      } as any)
+      })
       info('checkout session created.', { id: session.id })
-      return { clientSecret: (session as any).client_secret }
+      return { clientSecret: session.client_secret }
     } catch (err) {
       warn('checkout session create error.', { err })
       throw new https.HttpsError('invalid-argument', JSON.stringify(err))


### PR DESCRIPTION
## Summary
- Bumps `stripe` npm package from `^8.210.0` to `^22.3.2` and updates the pinned API version from `2020-08-27` to `2026-06-24.dahlia`.
- Removes the `as any` workarounds around `checkout.sessions.create`/`client_secret` now that embedded-checkout types are native to the SDK.
- Fixes the one real breaking change surfaced by the type-check: Checkout's `ui_mode` value `'embedded'` was renamed to `'embedded_page'` in this API version range.
- First PR in a larger effort to add a yearly recurring (subscription) membership payment option — see the full rollout plan for context. This PR is scoped to just the SDK upgrade so it can be regression-tested in isolation before any new subscription code is added.

## Test plan
- [x] `npm --prefix functions run build` (lint + tsc) passes clean.
- [ ] **Not yet done** — manually complete a full one-time `/join` payment with a Stripe test card against this branch's deployed functions, and confirm `membershipExpiresAt` extends, a `users/{uid}/transactions` doc is written, and the welcome email queues, exactly as before the bump. This repo has no local Firebase emulator config or local Stripe test secret key, so this needs either a deploy of this branch or local secrets to verify at runtime — flagging as **do not merge until this passes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)